### PR TITLE
fix #8 add export of builtins to getting started shims

### DIFF
--- a/getting-started/kojo-english.scala
+++ b/getting-started/kojo-english.scala
@@ -10,4 +10,4 @@ or directly from https://scala-cli.virtuslab.org/install  */
 // The lines below make English commands available on top level:
 
 export net.kogics.kojo.English.*, CanvasAPI.*, TurtleAPI.* 
-export builtins.{TurtleAPI => _, CanvasAPI => _, *}
+export builtins.{TurtleAPI as _, CanvasAPI as _, *}

--- a/getting-started/kojo-english.scala
+++ b/getting-started/kojo-english.scala
@@ -1,10 +1,13 @@
 //> using scala "3"
 //> using lib "net.kogics:kojo-lib:0.1.1,url=https://github.com/litan/kojo-lib/releases/download/v0.1.1/kojo-lib-assembly-0.1.1.jar"
 
-/* The above directives enables scala-cli to use Kojo in Scala 3 with this command:
+/* The above directives enable scala-cli to use Kojo in Scala 3 with this command:
 scala-cli repl .
-Install scala-cli from here: https://scala-cli.virtuslab.org/install  */
+Install scala-cli using the official installer from 
+https://www.scala-lang.org/download/
+or directly from https://scala-cli.virtuslab.org/install  */
 
-// The line below makes English commands available on top level:
+// The lines below make English commands available on top level:
 
 export net.kogics.kojo.English.*, CanvasAPI.*, TurtleAPI.* 
+export builtins.{TurtleAPI => _, CanvasAPI => _, *}

--- a/getting-started/kojo-swedish.scala
+++ b/getting-started/kojo-swedish.scala
@@ -1,10 +1,13 @@
 //> using scala "3"
 //> using lib "net.kogics:kojo-lib:0.1.1,url=https://github.com/litan/kojo-lib/releases/download/v0.1.1/kojo-lib-assembly-0.1.1.jar"
 
-/* The above directives enables scala-cli to use Kojo in Scala 3 with this command:
+/* The above directives enable scala-cli to use Kojo in Scala 3 with this command:
 scala-cli repl .
-Install scala-cli from here: https://scala-cli.virtuslab.org/install  */
+Install scala-cli using the official installer from 
+https://www.scala-lang.org/download/
+or directly from https://scala-cli.virtuslab.org/install  */
 
-// The line below makes Swedish and English commands available on top level:
+// The lines below make Swedish and English commands available on top level:
 
 export net.kogics.kojo.Swedish.*, padda.*, CanvasAPI.*, TurtleAPI.*
+export builtins.{TurtleAPI => _, CanvasAPI => _, *}

--- a/getting-started/kojo-swedish.scala
+++ b/getting-started/kojo-swedish.scala
@@ -10,4 +10,4 @@ or directly from https://scala-cli.virtuslab.org/install  */
 // The lines below make Swedish and English commands available on top level:
 
 export net.kogics.kojo.Swedish.*, padda.*, CanvasAPI.*, TurtleAPI.*
-export builtins.{TurtleAPI => _, CanvasAPI => _, *}
+export builtins.{TurtleAPI as _, CanvasAPI as _, *}


### PR DESCRIPTION
it should be enough to update the downloadable files of the existing 0.1.1 release
(although its source zip will be inconsistent wrt to the current detting-started dir, but that's a minor problem and it will be solved as soon as the next release is shipped eventually)