### PR TITLE
Update kojo-swedish.scala add export builtins.activateCanvas

### DIFF
--- a/getting-started/kojo-swedish.scala
+++ b/getting-started/kojo-swedish.scala
@@ -10,4 +10,5 @@ https://www.scala-lang.org/download/
 // The lines below make Swedish and English commands available on top level:
 
 export net.kogics.kojo.Swedish.*, padda.*, CanvasAPI.*, TurtleAPI.*
+export builtins.activateCanvas
 export java.awt.Color


### PR DESCRIPTION
In previous releases it worked to call activateCavnas() directly but we need this in the Swedish version to comply with published docs...